### PR TITLE
fix: only fetch published artefacts from cranach-api

### DIFF
--- a/src/helpers/fetchData.js
+++ b/src/helpers/fetchData.js
@@ -8,7 +8,7 @@ export async function fetchData(url, login, password, language) {
     const encodedCredentials = encode(`${login}:${password}`)
     // console.log("Encoded Credentials:", encodedCredentials) // Debugging line
 
-    const response = await fetch(`${url}&language=${language}`, {
+    const response = await fetch(`${url}&language=${language}&is_published=true`, {
       headers: new Headers({
         Authorization: `Basic ${encodedCredentials}`,
       }),


### PR DESCRIPTION
Append is_published=true to every API request so unpublished artefacts are excluded from the map data.